### PR TITLE
adding ability to use unix_socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The following configuration options exist for the plugin class:
 * **dbname**: Database name that will be connected to (default: None).
 * **dbhost**: Databse server host (default: 'localhost').
 * **dbport**: Databse server port (default: 3306).
+* **dbunixsocket**: Optionally, you can use a unix socket rather than TCP/IP.
 * **keyword**: The keyword argument name that triggers the plugin (default: 'db').
 * **autocommit**: Whether or not to commit outstanding transactions at the end of the request cycle (default: True).
 * **dictrows**: Whether or not to support dict-like access to row objects (default: True).

--- a/bottle_mysql.py
+++ b/bottle_mysql.py
@@ -61,10 +61,11 @@ class MySQLPlugin(object):
     name = 'mysql'
     api = 2
 
-    def __init__(self, dbuser=None, dbpass=None, dbname=None, dbhost='localhost', dbport=3306, autocommit=True,
-                 dictrows=True, keyword='db', charset='utf8', timezone=None):
+    def __init__(self, dbuser=None, dbpass=None, dbname=None, dbhost='localhost', dbport=3306, dbunixsocket=None,
+                 autocommit=True, dictrows=True, keyword='db', charset='utf8', timezone=None):
         self.dbhost = dbhost
         self.dbport = dbport
+        self.dbunixsocket = dbunixsocket
         self.dbuser = dbuser
         self.dbpass = dbpass
         self.dbname = dbname
@@ -104,6 +105,7 @@ class MySQLPlugin(object):
 
         dbhost = g('dbhost', self.dbhost)
         dbport = g('dbport', self.dbport)
+        dbunixsocket = g('dbunixsocket', self.dbunixsocket)
         dbuser = g('dbuser', self.dbuser)
         dbpass = g('dbpass', self.dbpass)
         dbname = g('dbname', self.dbname)
@@ -126,9 +128,10 @@ class MySQLPlugin(object):
                 # Using DictCursor lets us return result as a dictionary instead of the default list
                 if dictrows:
                     con = MySQLdb.connect(dbhost, dbuser, dbpass, dbname, dbport, cursorclass=cursors.DictCursor,
-                                          charset=charset, use_unicode=True)
+                                          charset=charset, use_unicode=True, unix_socket=dbunixsocket)
                 else:
-                    con = MySQLdb.connect(dbhost, dbuser, dbpass, dbname, dbport, charset=charset)
+                    con = MySQLdb.connect(dbhost, dbuser, dbpass, dbname, dbport, charset=charset, 
+                                          unix_socket=dbunixsocket)
                 cur = con.cursor()
                 if timezone:
                     cur.execute("set time_zone=%s", (timezone, ))


### PR DESCRIPTION
Sometimes connect to db via socket is the only possible way.
This fix introduces `dbunixsocket` configuration option that will be passed to connect method as usual `unix_socket` argument.