### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Bottle-MySQL
 ============
 [![Build Status](https://travis-ci.org/tg123/bottle-mysql.svg?branch=master)](https://travis-ci.org/tg123/bottle-mysql)
-[![Latest Version](https://pypip.in/version/bottle-mysql/badge.svg)](https://pypi.python.org/pypi/bottle-mysql/)
-[![Downloads](https://pypip.in/download/bottle-mysql/badge.svg)](https://pypi.python.org/pypi/bottle-mysql/)
+[![Latest Version](https://img.shields.io/pypi/v/bottle-mysql.svg)](https://pypi.python.org/pypi/bottle-mysql/)
+[![Downloads](https://img.shields.io/pypi/dm/bottle-mysql.svg)](https://pypi.python.org/pypi/bottle-mysql/)
 
 MySQL is the world's most used relational database management system (RDBMS) that runs
 as a server providing multi-user access to a number of databases.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20bottle-mysql))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `bottle-mysql`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.