### PR TITLE
Replace deprecated function

### DIFF
--- a/bottle_mysql.py
+++ b/bottle_mysql.py
@@ -119,7 +119,7 @@ class MySQLPlugin(object):
 
         # Test if the original callback accepts a 'db' keyword.
         # Ignore it if it does not need a database handle.
-        _args = inspect.getargspec(_callback)
+        _args = inspect.getfullargspec(_callback)
         if keyword not in _args.args:
             return callback
 


### PR DESCRIPTION
Replace deprecated function `getargspec` with `getfullargspec`.

In python 3.11, the `getargspec` function is not part of `inspect` anymore.

See https://docs.python.org/3.11/library/inspect.html#inspect.getfullargspec